### PR TITLE
feat(tokenizer): try to parse current value even if is_at_end, and return ParseError in parser

### DIFF
--- a/include/cpplox/parser.hpp
+++ b/include/cpplox/parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cpplox/error.hpp>
 #include <cpplox/expression.hpp>
 #include <cpplox/token.hpp>
 
@@ -15,7 +16,7 @@ public:
   /**
     @brief <expression> ::= <equality>
    */
-  auto expression() -> std::optional<Expr>;
+  auto expression() -> std::variant<Expr, ParseError>;
 
 private:
   Tokens tokens_;
@@ -24,32 +25,32 @@ private:
   /**
     @brief <equality> ::= <comparison> (("==" | "!=") <comparison>)*
    */
-  auto equality() -> std::optional<Expr>;
+  auto equality() -> std::variant<Expr, ParseError>;
 
   /**
    * @brief <comparison> ::= <term> ((">" | "<" | ">=" | "<=") <term>)*
    */
-  auto comparison() -> std::optional<Expr>;
+  auto comparison() -> std::variant<Expr, ParseError>;
 
   /**
    * @brief <term> ::= <factor> (("-" | "+") <factor>)*
    */
-  auto term() -> std::optional<Expr>;
+  auto term() -> std::variant<Expr, ParseError>;
 
   /**
    * @brief <factor> ::= <unary> (("/" | "*") <unary>)*
    */
-  auto factor() -> std::optional<Expr>;
+  auto factor() -> std::variant<Expr, ParseError>;
 
   /**
    * @brief <unary> ::= ("!" | "-") <unary> | <primary>
    */
-  auto unary() -> std::optional<Expr>;
+  auto unary() -> std::variant<Expr, ParseError>;
 
   /**
    * @brief <primary> ::= NUMBER | STRING | "true" | "false" | "nil" | "(" <expression> ")"
    */
-  auto primary() -> std::optional<Expr>;
+  auto primary() -> std::variant<Expr, ParseError>;
 
   template <typename... Types>
   auto match(const Types... types) const -> bool;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <cpplox/error.hpp>
 #include <cpplox/expression.hpp>
 #include <cpplox/parser.hpp>
+#include <cpplox/variant.hpp>
 
 #include <readline/history.h>
 #include <readline/readline.h>
@@ -122,7 +123,7 @@ auto main() -> int
       Token{lox::TokenType::Number, "45.67", 1, 0}, Token{lox::TokenType::RightParen, ")", 1, 0}};
     auto parser = lox::Parser(tokens);
     auto parsed = parser.expression();
-    if (parsed) {
+    if (lox::is_variant_v<lox::Expr>(parsed)) {
       std::cout << "parse success" << std::endl;
     }
   }
@@ -134,7 +135,7 @@ auto main() -> int
       Token{lox::TokenType::Number, "45.67", 1, 0}};
     auto parser = lox::Parser(tokens);
     auto parsed = parser.expression();
-    if (parsed) {
+    if (lox::is_variant_v<lox::Expr>(parsed)) {
       std::cout << "parse success" << std::endl;
     }
   }

--- a/test/test_paser.cpp
+++ b/test/test_paser.cpp
@@ -1,0 +1,43 @@
+#include <cpplox/parser.hpp>
+#include <cpplox/tokenizer.hpp>
+#include <cpplox/variant.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(Tokenizer, parse_success_simple_expr)
+{
+  const std::string source = R"(-123 * (45.67))";
+  auto tokenizer = lox::Tokenizer(source);
+  const auto result = tokenizer.take_tokens();
+  EXPECT_EQ(lox::is_variant_v<lox::Tokens>(result), true);
+
+  const auto & tokens = lox::as_variant<lox::Tokens>(result);
+  EXPECT_EQ(tokens.size(), 6);
+
+  auto parser = lox::Parser(tokens);
+  const auto parse_result = parser.expression();
+  EXPECT_EQ(parse_result.has_value(), true);
+
+  EXPECT_EQ(lox::to_lisp_repr(parse_result.value()), "(* (- 123) (group 45.67))");
+}
+
+TEST(Tokenizer, parse_fail_simple_expr)
+{
+  const std::string source = R"(-123 * (45.67 + 123)";
+  auto tokenizer = lox::Tokenizer(source);
+  const auto result = tokenizer.take_tokens();
+  EXPECT_EQ(lox::is_variant_v<lox::Tokens>(result), true);
+
+  const auto & tokens = lox::as_variant<lox::Tokens>(result);
+
+  auto parser = lox::Parser(tokens);
+  const auto parse_result = parser.expression();
+
+  EXPECT_EQ(parse_result.has_value(), false);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_paser.cpp
+++ b/test/test_paser.cpp
@@ -16,9 +16,10 @@ TEST(Tokenizer, parse_success_simple_expr)
 
   auto parser = lox::Parser(tokens);
   const auto parse_result = parser.expression();
-  EXPECT_EQ(parse_result.has_value(), true);
+  EXPECT_EQ(lox::is_variant_v<lox::Expr>(parse_result), true);
 
-  EXPECT_EQ(lox::to_lisp_repr(parse_result.value()), "(* (- 123) (group 45.67))");
+  const auto & expr = lox::as_variant<lox::Expr>(parse_result);
+  EXPECT_EQ(lox::to_lisp_repr(expr), "(* (- 123) (group 45.67))");
 }
 
 TEST(Tokenizer, parse_fail_simple_expr)
@@ -33,7 +34,11 @@ TEST(Tokenizer, parse_fail_simple_expr)
   auto parser = lox::Parser(tokens);
   const auto parse_result = parser.expression();
 
-  EXPECT_EQ(parse_result.has_value(), false);
+  EXPECT_EQ(lox::is_variant_v<lox::ParseError>(parse_result), true);
+  const auto & err = lox::as_variant<lox::ParseError>(parse_result);
+  EXPECT_EQ(err.kind, lox::ParseErrorKind::UnmatchedParenError);
+  EXPECT_EQ(err.line, 1);
+  EXPECT_EQ(err.column, 8);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## before

if reached `is_at_end` while parsing Number for example, returned `NonTerminatedNumberError`

## after

return current number as much as possible instead.

because 

```
-123 * (123 + 45.6
```

is invalid, and I prefer "UnmatcheRightParenError" to "NonTerminatedNumbrError"