### PR TITLE
chore(ci): fix ubuntu version

### DIFF
--- a/.github/workflows/gtest.yaml
+++ b/.github/workflows/gtest.yaml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   # this should be the name used in "Require status checks to pass"
   check-gtest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`-lreadline` is not found by default on Ubuntu24.04, so fix to Ubuntu22.04